### PR TITLE
Remove python3.8 dependencies

### DIFF
--- a/brainlit/feature_extraction/base.py
+++ b/brainlit/feature_extraction/base.py
@@ -9,7 +9,7 @@ import time
 from cloudvolume import CloudVolume
 import feather
 from joblib import Parallel, delayed
-from typing import Optional, List, Union, Tuple, Literal
+from typing import Optional, List, Union, Tuple
 
 
 class BaseFeatures(BaseEstimator):

--- a/brainlit/utils/session.py
+++ b/brainlit/utils/session.py
@@ -12,7 +12,7 @@ from brainlit.algorithms.generate_fragments.tube_seg import tubes_from_paths
 import napari
 import warnings
 import networkx as nx
-from typing import Optional, List, Union, Tuple, Literal
+from typing import Optional, List, Union, Tuple
 from brainlit.utils.util import (
     check_type,
     check_size,

--- a/brainlit/utils/upload.py
+++ b/brainlit/utils/upload.py
@@ -8,7 +8,7 @@ import joblib
 from glob import glob
 import argparse
 from psutil import virtual_memory
-from typing import Optional, Sequence, Union, Literal, Tuple, List
+from typing import Optional, Sequence, Union, Tuple, List
 import contextlib
 
 import tifffile as tf
@@ -30,7 +30,7 @@ def get_volume_info(
     image_dir: str,
     num_resolutions: int,
     channel: Optional[int] = 0,
-    extension: Optional[Literal["tif"]] = "tif",
+    extension: Optional[str] = "tif",
 ) -> Tuple[List, List, List, Tuple, List]:
     """Get filepaths along the octree-format image directory
 
@@ -100,8 +100,8 @@ def create_cloud_volume(
     num_resolutions: int,
     chunk_size: Optional[Sequence[int]] = None,
     parallel: Optional[bool] = False,
-    layer_type: Optional[Literal["image", "segmentaion", "annotation"]] = "image",
-    dtype: Optional[Literal["uint16", "uint64"]] = None,
+    layer_type: Optional[str] = "image",
+    dtype: Optional[str] = None,
     commit_info: Optional[bool] = True,
 ) -> CloudVolumePrecomputed:
     """Create CloudVolume object and info file.


### PR DESCRIPTION
Regarding to issue #133, this PR is used to merge python3.7-experimental branch into documentation branch for Windows users. Then windows users can use python3.7 to download data and finish the tutorial notebook for installation.

The object typing.Literal is new in version 3.8, seeing this in the [link](https://docs.python.org/3/library/typing.html#typing.Literal). Since there are some unsolved errors described in issue #124 when using version 3.8 for downloading tutorial notebook, we had to use version 3.7 by now. During downloading tutorial with version 3.7 in documentation branch, the only error was `ImportError: cannot import name 'Literal' from 'typing'` . Therefore, removing typing.Literal is necessary.